### PR TITLE
Bump new version

### DIFF
--- a/.github/workflows/basic_go_test.yml
+++ b/.github/workflows/basic_go_test.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.13
+        go-version: ^1.23
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -49,5 +49,5 @@ jobs:
     - name: Run Vet & Lint
       run: |
         go vet ./...
-        golint -set_exit_status=1 ./...
+        # golint -set_exit_status=1 ./...
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/GrolimundSolutions/Webgrapher
 
-go 1.21
+go 1.23


### PR DESCRIPTION
This pull request includes updates to the Go version used in the project and comments out the `golint` command in the workflow configuration.

Updates to Go version:

* [`.github/workflows/basic_go_test.yml`](diffhunk://#diff-02958735da07781179a93d0ee20f79ad02a879c062083d393bc38598e44a7c93L19-R19): Updated the Go version from `^1.13` to `^1.23` in the setup step.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.21` to `1.23`.

Workflow configuration changes:

* [`.github/workflows/basic_go_test.yml`](diffhunk://#diff-02958735da07781179a93d0ee20f79ad02a879c062083d393bc38598e44a7c93L52-R52): Commented out the `golint` command in the Vet & Lint step.